### PR TITLE
Fix landing-page pointer error + parallelize Montserrat load

### DIFF
--- a/src/components/LandingHero.astro
+++ b/src/components/LandingHero.astro
@@ -576,7 +576,6 @@ const canvasAttrs: Record<string, string> = { layoutsubtree: '' };
     function onPointerDown() {
       isDragging.value = true;
       hoverTarget = 1;
-      glCanvas!.setPointerCapture?.(0);
     }
 
     function onPointerUp() {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -119,6 +119,18 @@ const websiteJsonLd = {
     <meta name="theme-color" content="#0a0a0f" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
 
+    {/* Montserrat — preconnect so the TCP/TLS handshake runs in
+        parallel with HTML parsing, then load the stylesheet directly
+        so the preload scanner picks it up before <body>. Loading via
+        CSS `@import` would chain the request behind global.css and
+        delay first text paint. */}
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&display=swap"
+    />
+
     {/* Favicon — En Dash brand mark, copied from endash.us. */}
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,8 +3,10 @@
    En Dash Consulting branding
    ============================================ */
 
-/* --- Montserrat font --- */
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&display=swap');
+/* --- Montserrat font ---
+   Loaded via <link rel="preconnect"> + <link rel="stylesheet"> in
+   BaseLayout.astro. Using @import here would chain the font CSS
+   request behind this stylesheet, delaying text render. */
 
 /* --- Design tokens --- */
 :root {


### PR DESCRIPTION
## Summary
- **LandingHero pointer error**: drop `glCanvas.setPointerCapture(0)` in `onPointerDown`. The hardcoded pointer id `0` threw `NotFoundError: No active pointer with the given id is found` on every click in the hero. `pointermove`/`pointerup` already listen on `window`, so capture served no functional purpose.
- **Montserrat font loading**: replace the render-blocking `@import url(fonts.googleapis.com/...)` in `global.css` with `<link rel="preconnect">` + `<link rel="stylesheet">` in `BaseLayout.astro`'s `<head>`. Eliminates the HTML → CSS → `@import` CSS → font-files waterfall Lighthouse flagged; the preload scanner now discovers the font stylesheet while HTML is still parsing.

## Test plan
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npx playwright test landing-hero --project=chrome-canary` — 11/11 pass
- [x] `npx playwright test a11y-audit --project=chrome-canary` — 26/26 pass
- [x] Manual: click inside the hero in Chrome Canary with the flag on; no `NotFoundError` in the console
- [x] Manual: Lighthouse run on `/` — confirm the font-loading opportunity is gone or much smaller

🤖 Generated with [Claude Code](https://claude.com/claude-code)