### PR TITLE
Prevent page scroll when dragging frost panel with touch

### DIFF
--- a/src/content/demos/frosted-glass-backdrop/demo.html
+++ b/src/content/demos/frosted-glass-backdrop/demo.html
@@ -1268,6 +1268,7 @@ void main() {
         "touchmove",
         (e) => {
           if (!isDragging) return;
+          e.preventDefault();
           const touch = e.touches[0];
           const dx = touch.clientX - dragStartX;
           const dy = touch.clientY - dragStartY;
@@ -1277,7 +1278,7 @@ void main() {
           applyPanelPosition();
           requestRepaint();
         },
-        { passive: true },
+        { passive: false },
       );
 
       window.addEventListener("touchend", () => {


### PR DESCRIPTION
Previously, dragging the frost panel via touch gestures would trigger both the panel drag and page scrolling simultaneously, leading to an unexpected and confusing interaction for the user.

This change prevents default touch scrolling by:
1. Changing the `touchmove` listener from passive to active (`{ passive: false }`).
2. Calling `e.preventDefault()` inside `touchmove` when a drag is in progress.

This aligns the touch behavior with the existing mouse-based dragging interaction.